### PR TITLE
Capture stdin

### DIFF
--- a/tasks/execute.js
+++ b/tasks/execute.js
@@ -134,6 +134,7 @@ module.exports = function (grunt) {
 				cmd: 'node',
 				args: args,
 				opts: {
+					stdio: 'inherit',
 					cwd: (context.options.cwd !== null) ? context.options.cwd : path.dirname(src)
 				}
 			},
@@ -151,12 +152,6 @@ module.exports = function (grunt) {
 				}
 			}
 		);
-		child.stdout.on('data', function (data) {
-			grunt.log.write(data);
-		});
-		child.stderr.on('data', function (data) {
-			grunt.log.write(('' + data).red);
-		});
 	}
 
 	function pluralise(count, str) {


### PR DESCRIPTION
I'm trying to execute a couple node scripts via grunt that utilize [`prompt`](https://github.com/flatiron/prompt). However, grunt-execute just hangs, not recognizing the input.

I've attempted to fix by setting `{ stdio: 'inherit' }` in [spawn.opts](https://github.com/Bartvds/grunt-execute/blob/master/tasks/execute.js#L136) according to [child_proces](http://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options). This is close, but not exactly the same as the existing error handling.

Any other ideas?
