### PR TITLE
Added support for node env variables via env options object

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -68,6 +68,14 @@ module.exports = function (grunt) {
 				},
 				src: ['test/fixtures/**/node.args.*js']
 			},
+			node_envs: {
+				options: {
+					env: {
+						FOO: 'bar'
+					}
+				},
+				src: ['test/fixtures/**/node.envs.*js']
+			},
 			node_exit: {
 				// will crash
 				src: ['test/fixtures/node.exit.one.js']
@@ -171,6 +179,7 @@ module.exports = function (grunt) {
 
 	grunt.registerTask('pass', [
 		'execute:node_args',
+		'execute:node_envs',
 		'execute:node_async',
 		'execute:node_sync',
 		'execute:harmony_on',

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# grunt-execute 
+# grunt-execute
 
 [![Build Status](https://secure.travis-ci.org/Bartvds/grunt-execute.png?branch=master)](http://travis-ci.org/Bartvds/grunt-execute) [![Dependency Status](https://gemnasium.com/Bartvds/grunt-execute.png)](https://gemnasium.com/Bartvds/grunt-execute) [![NPM version](https://badge.fury.io/js/grunt-execute.png)](http://badge.fury.io/js/grunt-execute)
 
@@ -62,6 +62,15 @@ grunt.initConfig({
 			},
 			src: ['script.js']
 		},
+		simple_target_with_envs: {
+			options: {
+				// execute node with additional ENV variables
+				env: {
+					ARG: 'arg1'
+				}
+			},
+			src: ['script.js']
+		},
 		simple_target_with_harmony: {
 			options: {
 				// pass arguments to node itself (eg: before script parameter)
@@ -101,7 +110,7 @@ grunt.initConfig({
 			call: function(grunt, options, async){
 				// get the callback
 				var done = async();
-				
+
 				setTimeout(function(){
 					grunt.log.writeln('Done!')
 					done(err);
@@ -134,6 +143,7 @@ grunt.initConfig({
 
 ## Versions
 
+* 0.2.3 - Add support for node ENV variables via env options object
 * 0.2.2 - Add support for node arguments, via `nodeargs` (like `--harmony`)
 * 0.2.1 - Non-zero exit code will fail grunt, add support for commandline arguments
 * 0.1.5 - Added callback module & inline function support

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-execute",
   "description": "Execute code in node",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "homepage": "https://github.com/Bartvds/grunt-execute",
   "author": {
     "name": "Bart van der Schoor",

--- a/tasks/execute.js
+++ b/tasks/execute.js
@@ -128,13 +128,16 @@ module.exports = function (grunt) {
 			args = context.options.nodeargs.concat(args);
 		}
 
+		var envs = context.options.env ? context.options.env : {};
+
 		//use spawn so we don't have to depend on process.exit();
 		var child = grunt.util.spawn(
 			{
 				cmd: 'node',
 				args: args,
 				opts: {
-					cwd: (context.options.cwd !== null) ? context.options.cwd : path.dirname(src)
+					cwd: (context.options.cwd !== null) ? context.options.cwd : path.dirname(src),
+					env: envs
 				}
 			},
 			function (error, result, code) {

--- a/test/execute_test.js
+++ b/test/execute_test.js
@@ -24,10 +24,12 @@ var grunt = require('grunt');
 var path = require('path');
 var helper = require('./helper');
 
-var easyTestOutput = function (test, name, append) {
+var easyTestOutput = function (test, name, append, prepend) {
 	var ctx = helper.getContext(name, true);
 	var actual = grunt.file.read(ctx.dest);
-	var expected = ctx.data + (typeof append !== 'undefined' ? append : '');
+  var before = (typeof prepend !== 'undefined' ? (prepend + ' ') : '');
+  var after = (typeof append !== 'undefined' ? append : '');
+	var expected = before + ctx.data + after;
 	var base = path.basename(name);
 	test.strictEqual(actual, expected, base);
 };
@@ -58,6 +60,11 @@ exports.execute = {
 		}
 		test.done();
 	},
+  envs: function (test) {
+    test.expect(1);
+    easyTestOutput(test, 'node.envs.js', '', 'FOO=bar');
+    test.done();
+  },
 	module_sync: function (test) {
 		test.expect(1);
 		easyTestOutput(test, 'module.sync.js');

--- a/test/fixtures/node.envs.js
+++ b/test/fixtures/node.envs.js
@@ -1,0 +1,12 @@
+var util = require('util');
+var help = require('../helper.js');
+var ctx = help.getContext(__filename);
+
+var fs = require('fs');
+
+setTimeout(function () {
+  console.log("ENV " + util.inspect(process.env));
+  fs.writeFile(ctx.dest, Object.keys(process.env)[0] + '=' + process.env[Object.keys(process.env)[0]] + ' ' + ctx.data, function (err) {
+    if(err) throw err;
+  });
+}, 100);


### PR DESCRIPTION
Hey! Need this functionality a while ago and your grunt task fit the bill perfectly minus the ability to pass ENV variables to the spawned tasks. So here is the functionality that sufficed for my requirements and though I'd give it back to you.

Let me know if you see any issues with this or anything that needs to be changed.

Thanks!
Dan
